### PR TITLE
Fixing Version 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ long_description = open('README.md').read()
 
 setup(
   name='Discord Webhooks',
-  version='1.0.3',
+  version='1.0.4',
   py_modules=['discord_webhooks'],
   url='https://github.com/JamesIves/discord-webhooks',
   author='James Ives',
   author_email='iam@jamesiv.es',
-  description='Easy to use package for Python which allows for sending of webhooks to a Discord server.',
+  description='Easy to use module for Python which allows for sending of webhooks to a Discord server.',
   long_description=long_description,
   license='MIT',
   install_requires=[


### PR DESCRIPTION
**Description**
> Provide a description of what your changes do.

Fixes a version issue where `1.0.3` could only be installed for Python2 and not 3.

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

With these changes Python3 should be able to install the module via pip. `pip install Discord-Webhooks`. 
